### PR TITLE
Add pound character support

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,23 @@ describe('t', () => {
     expect(i18n.t('some_cats', { N: '8' })).to.equal('There are 8 cats here.');
   });
 
+  it('interpolates plural with pounds', () => {
+    i18n.set('en', {
+      some_cats:
+        'There {N,plural,=0{is # cat} =1{is # cat, my #st cat} other{are # cats}} here.',
+      some_dogs:
+        "There {N,plural,=0{is # dog} =1{is # dog '#'cute '#'pet} other{are # dogs}} here.",
+    });
+
+    expect(i18n.t('some_cats', { N: '0' })).to.equal('There is 0 cat here.');
+    expect(i18n.t('some_cats', { N: '1' })).to.equal('There is 1 cat, my 1st cat here.');
+    expect(i18n.t('some_cats', { N: '8' })).to.equal('There are 8 cats here.');
+
+    expect(i18n.t('some_dogs', { N: '0' })).to.equal('There is 0 dog here.');
+    expect(i18n.t('some_dogs', { N: '1' })).to.equal('There is 1 dog #cute #pet here.');
+    expect(i18n.t('some_dogs', { N: '8' })).to.equal('There are 8 dogs here.');
+  });
+
   it('interpolates select', () => {
     i18n.set('en', {
       love_pet:


### PR DESCRIPTION
Hi 👋

First, thanks for this amazing library, it works perfectly and we use it in various projects.
I explain our need with this pull request: our translation team uses https://lokalise.com, a tool that supports `#` character replacement in plural expressions.

More infos about it:
- https://unicode-org.github.io/icu/userguide/format_parse/messages/#complex-argument-types
- https://github.com/messageformat/messageformat/blob/master/packages/parser/README.md#messageformatparser

This pull request add support for it, in a quite ugly but performant way 😅
It also support escaping the character using simple quotes, similarly as other parsers.

In exemple:

```
There {N,plural,=0{is # cat} =1{is # cat, my #st cat} other{are # cats}}. => There is 1 cat, my 1st cat (with N = 1)
There {N,plural,=0{is # dog} =1{is # dog '#'cute '#'pet} other{are # dogs}}. => There is 1 dog #cute #pet (with N = 1)
```